### PR TITLE
react-native-gesture-handler as peer decency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,11 @@
   "types": "index.d.ts",
   "dependencies": {
     "react": "^18.2.0",
-    "react-native": "^0.71.8",
-    "react-native-gesture-handler": "^2.10.1"
+    "react-native": "^0.71.8"
   },
+  "peerDependencies": {
+    "react-native-gesture-handler": "^2.10.1"
+  }
   "devDependencies": {
     "@types/react": "^18.2.6"
   }


### PR DESCRIPTION
"rn-gesture-swipeable-flatlist has a peer dependency on react-native-gesture-handler. It will be installed automatically when you install this package. However, please ensure that your project meets the requirements for react-native-gesture-handler."